### PR TITLE
Fixed Error 500 on Event Signup

### DIFF
--- a/app/Domain/EventSignups/EventSignupService.php
+++ b/app/Domain/EventSignups/EventSignupService.php
@@ -82,7 +82,7 @@ class EventSignupService extends ResourceService {
 		if ( ! $event->allowsSignups() )
 			throw new DomainException( 'Event does not allow signups' );
 
-		if ( $event->hasSignupFromUser( $this->input['user_id'] ) )
+		if ( $event->hasSignupFromUser( $this->user->id() ) )
 			throw new DomainException( 'User already signed up to event' );
 	}
 


### PR DESCRIPTION
This fixes Issue #93 
Lanager spits out a 500 Internal Server Error when signing up to an Event.
Logs reveal "Uncaught exception: ErrorException".
