### PR TITLE
Allow Normal Users (NonAdmins) to Signup to Events

### DIFF
--- a/app/Domain/EventSignups/EventSignupService.php
+++ b/app/Domain/EventSignups/EventSignupService.php
@@ -72,7 +72,7 @@ class EventSignupService extends ResourceService {
 
 		if ( ! $this->user->hasRole('Events Admin') )
 		{
-			if ( $this->input['user_id'] != $this->user->id() )
+			if ( $input['user_id'] != $this->user->id() )
 				throw new AuthorisationException( 'You may only sign yourself up to events' );
 
 			if ( ! $event->isOpenForSignups() )


### PR DESCRIPTION
Allows Normal Users to Sign up to Events (Admins have permission, while normal users do not).
Addition to #93

The real issue is currently $this->input['user_id'], however using $input['user_id'] does the job just fine.
