### PR TITLE
Make "List" the Default View, instead of "Timetable".

### DIFF
--- a/app/views/events/index.blade.php
+++ b/app/views/events/index.blade.php
@@ -7,23 +7,25 @@
 		{{
 			Navigation::tabs([
 			[
-				'title' => 'Timetable',
-				'link' => route('events.index', ['tab' => 'timetable']),
-				'active' => (Input::get('tab') == 'timetable' OR empty(Input::get('tab')) ),
-			],
-			[
 				'title' => 'List',
 				'link' => route('events.index', ['tab' => 'list']),
-				'active' => Input::get('tab') == 'list',
+				'active' => (Input::get('tab') == 'list' OR empty(Input::get('tab')) ),
 			],
+			[
+				'title' => 'Timetable',
+				'link' => route('events.index', ['tab' => 'timetable']),
+				'active' => Input::get('tab') == 'timetable',
+			],
+
 			])
 		}}
 	</div>
 
-	@if ( Input::get('tab') == 'timetable' OR empty(Input::get('tab')) )
-		@include('events.partials.timetable' )
-	@elseif ( Input::get('tab') == 'list' )
+	@if ( Input::get('tab') == 'list' OR empty(Input::get('tab')) )
 		@include('events.partials.list', ['events' => $events] )
+	@elseif ( Input::get('tab') == 'timetable' )
+		@include('events.partials.timetable' )
+		
 	@endif
 	@include('buttons.create', ['resource' => 'events'])
 


### PR DESCRIPTION
This makes the default view as "List", instead of the "Timetable", whenever you click on the Events Tab on the navigation bar.
It also makes the "List" Button First in line, and makes the "Timetable" button last.

I have been using this edit for a while now with my own Install of Lanager, and it works great.
