### PR TITLE
Update README.md for installation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This unstable branch is where the work of upgrading to Laravel 5.6 is being done
 
 ### Steps
 
+- Enable the Ubuntu 18.04 universe repository: `sudo add-apt-repository universe`
+
 - Install required packages:
 
     ```


### PR DESCRIPTION
In order to install php7.2-zip and composer, universe needs to be enabled. php7.2-zip relies upon packages only available in universe, and composer is only available in universe.