### PR TITLE
Passport 1.0

### DIFF
--- a/app/Http/Controllers/Api/Oauth/UserController.php
+++ b/app/Http/Controllers/Api/Oauth/UserController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zeropingheroes\Lanager\Http\Controllers\Api\Oauth;
+
+use Zeropingheroes\Lanager\Http\Controllers\Controller;
+use Zeropingheroes\Lanager\Http\Resources\User as UserResource;
+
+class UserController extends Controller
+{
+    /**
+     * Display the specified resource.
+     *
+     * @param  \Zeropingheroes\Lanager\User $user
+     * @return UserResource
+     */
+    public function index()
+    {
+        $user = auth('api')->user()->load('accounts');
+        return new UserResource($user);
+    }
+}

--- a/app/Listeners/CreatePATIfMissing.php
+++ b/app/Listeners/CreatePATIfMissing.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zeropingheroes\Lanager\Listeners;
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class CreatePATIfMissing
+{
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle(Login $login)
+    {
+        $user = $login->user;
+        if($user->tokens()->where('name', 'Default')->where('revoked', 0)->count() == 0)
+            $user->createToken('Default')->accessToken;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -29,6 +29,7 @@ use Zeropingheroes\Lanager\Policies\EventPolicy;
 use Zeropingheroes\Lanager\User;
 use Zeropingheroes\Lanager\Policies\UserPolicy;
 use Zeropingheroes\Lanager\Venue;
+use Laravel\Passport\Passport;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -64,5 +65,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         Gate::resource('images', ImagePolicy::class);
+
+        Passport::routes();
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,6 +18,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         'Illuminate\Auth\Events\Login' => [
             'Zeropingheroes\Lanager\Listeners\UpdateLanAttendeesTable',
+            'Zeropingheroes\Lanager\Listeners\CreatePATIfMissing',
             'Zeropingheroes\Lanager\Listeners\AwardLanAchievementToAttendee',
             'Zeropingheroes\Lanager\Listeners\UpdateOutdatedUserAppsAfterSuccessfulAuth',
         ],

--- a/app/User.php
+++ b/app/User.php
@@ -4,10 +4,11 @@ namespace Zeropingheroes\Lanager;
 
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Passport\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use Notifiable;
+    use Notifiable, HasApiTokens;
 
     protected $fillable = [
         'username',

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "gilg4mesh/monolog-mysql": "^0.1.8",
         "graham-campbell/markdown": "^10.2",
         "laravel/framework": "5.8.*",
+        "laravel/passport": "^7.3",
         "laravel/socialite": "^3.0",
         "laravel/tinker": "^1.0",
         "socialiteproviders/steam": "^1.0",

--- a/config/auth.php
+++ b/config/auth.php
@@ -42,7 +42,7 @@ return [
         ],
 
         'api' => [
-            'driver' => 'token',
+            'driver' => 'passport',
             'provider' => 'users',
         ],
     ],

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,8 @@ Route::name('api.')->group(function () {
     Route::resource('lans.slides', 'Api\SlideController', ['only' => ['index', 'show']]);
     Route::resource('events', 'Api\EventController', ['only' => ['index', 'show']]);
     Route::resource('active-games', 'Api\ActiveGamesController', ['only' => ['index']]);
+
+    Route::get('oauth/user', 'Api\Oauth\UserController@index')->middleware('auth:api');
 });
 
 Route::fallback(function () {


### PR DESCRIPTION
* Added in laravel passport for oauth auth for external sites and API
* You'll need to use $user->tokens()->where('name', 'Default') instead of $user->api_token as the personal access tokens are not stored on the user model. The "Default" token should be created when a user first logs in.
* Created a single API endpoint /api/oauth/user to facilitate oauth external auth

You'll need to run:

php artisan migrate
php artisan passport:install